### PR TITLE
Fix requirements version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
-cupy
-chainer
-librosa
+cupy<6.0.0
+chainer<6.0.0
+librosa<0.7.0
 pysptk
 pyworld
 fastdtw


### PR DESCRIPTION
別PCで単独で`realtime-yukarin` をインストールした場合、
`become-yukarin`でバージョン指定がされていない為
`chainer 7.1.0` 及び `librosa 0.7.2` がインストールされてしまい下記のエラーが出ます。
cupyについては今後似たようなことがあるかもしれない為`yukarin`に合わせました。

```
ERROR: yukarin 0.1.0 has requirement chainer<6.0.0, but you'll have chainer 7.1.0 which is incompatible.
ERROR: yukarin 0.1.0 has requirement librosa<0.7.0, but you'll have librosa 0.7.2 which is incompatible.
```